### PR TITLE
Navegação para a tela de detalhes e Tela de detalhes do Pokémon 

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,11 @@ const routes: Routes = [
     redirectTo: 'home',
     pathMatch: 'full'
   },
+  {
+    path: 'pokemon/:id',
+    loadChildren: () => import('./pokemon-details/pokemon-details.module').then(m => m.PokemonDetailsPageModule)
+  },
+
 ];
 
 @NgModule({

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -5,7 +5,8 @@
 </ion-header>
 <ion-content [fullscreen]="true" class="ion-padding">
   <div class="pokemon-grid">
-    <ion-card *ngFor="let pokemon of pokemons" class="pokemon-card">
+    <ion-card *ngFor="let pokemon of pokemons" class="pokemon-card"
+      [routerLink]="['/pokemon', getPokemonId(pokemon.url)]">
       <ion-card-content>
         <img
           [src]="'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/' + getPokemonId(pokemon.url) + '.png'"

--- a/src/app/pokemon-details/pokemon-details-routing.module.ts
+++ b/src/app/pokemon-details/pokemon-details-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { PokemonDetailsPage } from './pokemon-details.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PokemonDetailsPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PokemonDetailsPageRoutingModule {}

--- a/src/app/pokemon-details/pokemon-details.module.ts
+++ b/src/app/pokemon-details/pokemon-details.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { PokemonDetailsPageRoutingModule } from './pokemon-details-routing.module';
+
+import { PokemonDetailsPage } from './pokemon-details.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    PokemonDetailsPageRoutingModule
+  ],
+  declarations: [PokemonDetailsPage]
+})
+export class PokemonDetailsPageModule {}

--- a/src/app/pokemon-details/pokemon-details.page.html
+++ b/src/app/pokemon-details/pokemon-details.page.html
@@ -1,0 +1,27 @@
+<ion-header translucent="true" class="custom-header">
+  <ion-toolbar>
+    <ion-title class="custom-title">{{ pokemon?.name | titlecase }}</ion-title>
+    <ion-button expand="block" color="medium" routerLink="/home" class="ion-margin-top">
+      ← Voltar para lista
+    </ion-button>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content [fullscreen]="true" class="ion-padding" *ngIf="pokemon">
+  <ion-card>
+    <ion-card-content>
+      <div class="sprite-container">
+        <img [src]="pokemon.sprites.front_default" alt="Front" />
+        <img [src]="pokemon.sprites.back_default" alt="Back" />
+        <img [src]="pokemon.sprites.front_shiny" alt="Front Shiny" />
+        <img [src]="pokemon.sprites.back_shiny" alt="Back Shiny" />
+      </div>
+      <h2>{{ pokemon.name | titlecase }}</h2>
+      <p><strong>ID:</strong> {{ pokemon.id }}</p>
+      <p><strong>Altura:</strong> {{ pokemon.height }}</p>
+      <p><strong>Peso:</strong> {{ pokemon.weight }}</p>
+      <p><strong>Tipos:</strong> {{ tipos.join(', ') }}</p>
+      <p><strong>Habilidades:</strong> {{ habilidades.join(', ') }}</p>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/src/app/pokemon-details/pokemon-details.page.scss
+++ b/src/app/pokemon-details/pokemon-details.page.scss
@@ -1,0 +1,12 @@
+.sprite-container {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+
+ion-card-content img {
+    width: 80px;
+    height: 80px;
+}

--- a/src/app/pokemon-details/pokemon-details.page.spec.ts
+++ b/src/app/pokemon-details/pokemon-details.page.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PokemonDetailsPage } from './pokemon-details.page';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+
+describe('PokemonDetailsPage', () => {
+  let component: PokemonDetailsPage;
+  let fixture: ComponentFixture<PokemonDetailsPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PokemonDetailsPage],
+      imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => '1'
+              }
+            }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PokemonDetailsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pokemon-details/pokemon-details.page.ts
+++ b/src/app/pokemon-details/pokemon-details.page.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-pokemon-details',
+  templateUrl: './pokemon-details.page.html',
+  styleUrls: ['./pokemon-details.page.scss'],
+  standalone: false
+})
+export class PokemonDetailsPage implements OnInit {
+  pokemon: any;
+  tipos: string[] = [];
+  habilidades: string[] = [];
+
+  constructor(private route: ActivatedRoute, private http: HttpClient) { }
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id');
+    this.http.get(`https://pokeapi.co/api/v2/pokemon/${id}`).subscribe((res: any) => {
+      this.pokemon = res;
+      this.tipos = res.types.map((t: any) => t.type.name);
+      this.habilidades = res.abilities.map((a: any) => a.ability.name);
+    });
+  }
+}


### PR DESCRIPTION
Implementar navegação para tela de detalhes do Pokémon e também, exibir informações detalhadas do Pokémon selecionado.
![Gravação de Tela 2025-06-26 160109](https://github.com/user-attachments/assets/284a94d8-43a3-4711-b76e-53d4d7f79efe)
